### PR TITLE
Updating GIT repo URL for Verilator

### DIFF
--- a/source/VexiiRiscv/HowToUse/index.rst
+++ b/source/VexiiRiscv/HowToUse/index.rst
@@ -34,7 +34,7 @@ On debian :
 
     # Verilator (optional, for simulations)
     sudo apt-get install git make autoconf g++ flex bison help2man
-    git clone http://git.veripool.org/git/verilator   # Only first time
+    git clone https://github.com/verilator/verilator.git # Only first time
     unsetenv VERILATOR_ROOT  # For csh; ignore error if on bash
     unset VERILATOR_ROOT  # For bash
     cd verilator


### PR DESCRIPTION
Verilator now moved their repo to GitHub